### PR TITLE
Sealed interface for the state

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ fun PokemonLookupPage() {
     // Here, we can easily set up our UI based on the async state of
     // our Command
     when {
-      search.isRunning -> Text("Searching..."),
+      search.isRunning -> Text("Searching...")
 
-      search.hasFailed -> Text("It didn't work!"),
+      search.hasFailed -> Text("It didn't work!")
 
       search.hasValue -> {
         LazyColumn {
@@ -66,7 +66,7 @@ fun PokemonLookupPage() {
             Text("${pokemon.Name} - ${pokemon.Information}")
           }
         }
-      },
+      }
 
       else -> Button(onClick = search::tryRun) { Text("Do it") }
     }

--- a/commands/src/androidTest/java/dev/anais/commands/test/Commands.kt
+++ b/commands/src/androidTest/java/dev/anais/commands/test/Commands.kt
@@ -11,11 +11,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import dev.anais.commands.rememberCommand
-import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/commands/src/main/java/dev/anais/commands/CommandStatus.kt
+++ b/commands/src/main/java/dev/anais/commands/CommandStatus.kt
@@ -1,0 +1,16 @@
+package dev.anais.commands
+
+sealed interface CommandStatus<out T> {
+    data object Idle : CommandStatus<Nothing>
+    data object Running : CommandStatus<Nothing>
+    data class Failure(val throwable: Throwable) : CommandStatus<Nothing>
+    data class Success<out T>(val data: T) : CommandStatus<Nothing>
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T> CommandStatus<T>.toResult(): Result<T>? = when (val state = this) {
+    is CommandStatus.Idle -> null
+    is CommandStatus.Running -> null
+    is CommandStatus.Failure -> Result.failure(state.throwable)
+    is CommandStatus.Success<*> -> Result.success(state.data as T)
+}


### PR DESCRIPTION
As discussed, I believe that using a `sealed interface` makes the command state more straightforward.
Also, it avoids using two `mutableStateOf` to represent the command state.

I did it while preserving your API.

I'm not trying to force this solution on you; I just wanted to show you. Feel free to close this PR if it is not what you wish for this project :slightly_smiling_face: 